### PR TITLE
Mob finder and rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,32 @@ If it can't get to a room, it just moves on to the next.
 * demonwalker.config.breadth
   * When asked to find the next room to move to, it will search this many rooms away from your current room before falling back to checking the distance to all the remaining rooms and choosing the shortest one. Defaults to 10
 * demonwalker.config.avoidList
-  * list of roomIDs to avoid in **all** walks. demonwalker:addAvoidRoom(roomID) and demonwalker:removeAvoidRoom(roomID) to add/remove items from the list. This table uses roomIDs as keys, it's advised not to alter it directly if you're not familiar with how it works.
+  * list of roomIDs to avoid in **all** walks. demonwalker:addAvoidRoom(roomID) and demonwalker:removeAvoidRoom(roomID) to add/remove items from the list. This table uses roomIDs as keys, it's advised not to alter it directly. See also the dwalk alias below
+
+## Alias
+
+* `dwalk`
+  * prints out the demonwalker configuration.
+* `dwalk usage`
+  * prints out usage information for dwalk alias set
+* `dwalk report`
+  * prints out the performance report for current walk, or last one completed if you're not currently using demonwalker.
+* `dwalk stop`
+  * stops demonwalker. Equivalent to raising the "demonwalker.stop" event
+* `dwalk move`
+  * Tells the walker to move on. Equivalent to raising the "demonwalker.move" event
+* `dwalk avoidList`
+  * prints out the global list of rooms to avoid in **all** walks
+* `dwalk avoid <roomID>`
+  * adds roomID to the global avoid list.
+* `dwalk unavoid <roomID>`
+  * removes roomID from the global avoid list.
+* `dwalk breadth <newBreadth>`
+  * Sets the number of rooms to search from your current one, before just checking all the remaining rooms for the closest. Defaults to 10, and you'll likely never need to change it.
+* `dwalk returnToStart <true/false>`
+  * Set returnToStart value. If true, will return to the room the walk started in when it's stopped/finished.
+* `dwalk debug <true/false>`
+  * Used to turn on/off debug. Will be kind of spammy if turned on, and mostly useful during development.
 
 ## Functions
 
@@ -41,6 +66,8 @@ If it can't get to a room, it just moves on to the next.
   * starts a walk. Options an optional table of options. Valid keys are
     * rooms: a list of roomIDs to visit. IE {1, 2, 4, 10} . If not provided will be the list of all rooms in the area.
     * avoidRooms: a list of roomIDs to make sure is not included in **this** walk. Not saved between walks.
+    * searchTargets: a list of items to check for. IE {"a thief on a leaf", "a dracnari hunk", "a dracnari dreamer"}. 
+      * If this list is provided, then demonwalker will check every room for each of these items, and if any of them are found then and only then will it raise `demonwalker.arrived`. This makes it easy to automate looking for one or more creatures or items in an area, without worrying about stopping the walker yourself.
 * demonwalker:performanceReport()
   * prints out some performance information on the current walk if still running a walk, or the last walk if one has been completed.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Demonnic Auto Walker
+# Demonwalker
 
 ## What is this thing
 
@@ -8,15 +8,15 @@ So you could, for instance, use this to write a set of scripts and triggers whic
 
 If it can't get to a room, it just moves on to the next.
 
-## Usage
+## Basic Usage
 
-1. Call the function demonnic.autowalker:init()
-1. listen for event "demonwalker.arrived" (It will call it for the current room you're in first before moving)
-1. do whatever you need to do
-1. `raiseEvent("demonwalker.move")`
-1. listen for event "demonwalker.arrived"
-1. do whatever you need to do
-1. etc etc
+* `demonwalker:init()`
+  * see entry for demonwalker:init() in [Functions](#functions) for more advanced usage. Called like this it will walk each room in the current area.
+* start loop
+* listen for event "demonwalker.arrived"
+* do whatever you need to do in the demonwalker.arrived event handler
+* `raiseEvent("demonwalker.move")`
+* repeat loop
 
 ## Stop moving now, please
 
@@ -24,8 +24,45 @@ If it can't get to a room, it just moves on to the next.
 
 ## Configuration
 
-* demonnic.autowalker.config.returnToStart
+* demonwalker.config.returnToStart
   * when true, will go back to the room where you started the autowalker when it is done (either all rooms visited, or demonwalker.stop event received)
+* demonwalker.config.breadth
+  * When asked to find the next room to move to, it will search this many rooms away from your current room before falling back to checking the distance to all the remaining rooms and choosing the shortest one. Defaults to 10
+* demonwalker.config.avoidList
+  * list of roomIDs to avoid in **all** walks. demonwalker:addAvoidRoom(roomID) and demonwalker:removeAvoidRoom(roomID) to add/remove items from the list. This table uses roomIDs as keys, it's advised not to alter it directly if you're not familiar with how it works.
+
+## Functions
+
+* demonwalker:addAvoidRoom(roomID)
+  * adds a room ID to the list of rooms to not include in **any** walks
+* demonwalker:removeAvoidRoom(roomID)
+  * removes a room ID from the list of rooms to not include in **any** walks
+* demonwalker:init(options)
+  * starts a walk. Options an optional table of options. Valid keys are
+    * rooms: a list of roomIDs to visit. IE {1, 2, 4, 10} . If not provided will be the list of all rooms in the area.
+    * avoidRooms: a list of roomIDs to make sure is not included in **this** walk. Not saved between walks.
+* demonwalker:performanceReport()
+  * prints out some performance information on the current walk if still running a walk, or the last walk if one has been completed.
+
+## Events
+
+### Listens for
+
+* demonwalker.move
+  * when this event is raised, if mmp is paused it will unpause it so it starts walking again. If it is not paused, then it will choose the closest unvisited room and begin walking to it.
+* demonwalker.stop
+  * when this event is raise, the current walk will end, and if demonwalker.config.returnToStart is true it will move back to the room the walk began in.
+* mmapper arrived
+  * when this event is raised, it means the speedwalk has ended and we're at the room we were moving to. demonwalker then does some housekeeping and raises `demonwalker.arrived`
+* mmapper failed path
+  * when this event is raised it means the speedwalk could not continue, so we make sure to remove the room we were moving to and then pick the next one and move to it
+
+### Raises
+
+* demonwalker.arrived
+  * raised when we have arrived at a new room, or a room which contains an item/mob we've been told to stop for. Should be listened for in order to signal that it is time to "do the thing", whatever that might be.
+* demonwalker.finished
+  * raised when the overall walk is finished, whether because it ran out of rooms to move to, or it was stopped using the `demonwalker.stop` event. Raised before the walk to the starting room is finished, to do something when that occurs listen for demonwalker.finished to register a one-time event handler for `mmapper arrived`
 
 ## Porting
 
@@ -35,10 +72,12 @@ It wouldn't be too difficult to port this to other mappers, but it would need:
 * a variable which holds the current roomID for checking (mmp.currentroom in IRE mapper)
 * an event which is raised when an autowalk completes successfully ("mmapper arrived" in IRE mapper)
 * an event which is raised when an autowalk fails ("mmapper failed path" in IRE mapper)
+* a way to pause, unpause, and check the paused status of the walker
 
-That's really it, everything else is handled by the autowalker. 
+That's really it, everything else is handled by the autowalker.
 
 TODO:
 
-* Make function called to start the autowalk, variable which holds the current roomID, and events raised for completed autowalk and failed autowalk configuration options
-* Make it work with the generic mapping script that ships with Mudlet itself (may require adjustments to the generic mapping script)
+* Make it work with the generic mapping script that ships with Mudlet itself (will require adjustments to the generic mapping script)
+
+* Make implementing the porting items above easier by making them configuration options.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If it can't get to a room, it just moves on to the next.
   * starts a walk. Options an optional table of options. Valid keys are
     * rooms: a list of roomIDs to visit. IE {1, 2, 4, 10} . If not provided will be the list of all rooms in the area.
     * avoidRooms: a list of roomIDs to make sure is not included in **this** walk. Not saved between walks.
-    * searchTargets: a list of items to check for. IE {"a thief on a leaf", "a dracnari hunk", "a dracnari dreamer"}. 
+    * searchTargets: a list of items to check for. IE {"a thief on a leaf", "a dracnari hunk", "a dracnari dreamer"}.
       * If this list is provided, then demonwalker will check every room for each of these items, and if any of them are found then and only then will it raise `demonwalker.arrived`. This makes it easy to automate looking for one or more creatures or items in an area, without worrying about stopping the walker yourself.
 * demonwalker:performanceReport()
   * prints out some performance information on the current walk if still running a walk, or the last walk if one has been completed.

--- a/src/aliases/demonwalker/aliases.json
+++ b/src/aliases/demonwalker/aliases.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "dwalk",
+    "regex": "^dwalk(?: (.*))?"
+  }
+]

--- a/src/aliases/demonwalker/dwalk.lua
+++ b/src/aliases/demonwalker/dwalk.lua
@@ -1,0 +1,65 @@
+if not matches[2] then
+  demonwalker:usage()
+  return
+end
+local function toBool(value)
+  if value == "true" or value == true then
+    return true
+  end
+  return false
+end
+local args = matches[2]:split(" ")
+local command = args[1]
+local value = args[2]
+if command == "report" then
+  demonwalker:performanceReport()
+  return
+elseif command == "stop" then
+  raiseEvent("demonwalker.stop")
+  return
+elseif command == "move" then
+  raiseEvent("demonwalker.move")
+  return
+elseif command == "config" then
+  demonwalker:displayConfig()
+  return
+elseif command == "breadth" then
+  value = tonumber(value)
+  if value then
+    demonwalker.config.breadth = value
+  end
+  demonwalker:save()
+  return
+elseif command == "returnToStart" then
+  demonwalker.config.returnToStart = toBool(value)
+  demonwalker:save()
+  return
+elseif command == "debug" then
+  demonwalker.config.debug = toBool(value)
+  demonwalker:save()
+  return
+elseif command == "avoid" then
+  value = tonumber(value)
+  if value then 
+    demonwalker:addAvoidRoom(value)
+    demonwalker:echo(string.format("Added %d to avoidList", value))
+  end
+  return
+elseif command == "unavoid" then
+  value = tonumber(value)
+  if value then
+    demonwalker:removeAvoidRoom(value)
+    demonwalker:echo(string.format("Removed %s from avoidList", tostring(value)))
+  end
+  return
+elseif command == "avoidList" then
+  demonwalker:printAvoidList()
+  return
+elseif command == "load" then
+  demonwalker:load()
+  return
+elseif command == "save" then
+  demonwalker:save()
+  return
+end
+demonwalker:usage(matches[1])

--- a/src/scripts/demonwalker/Code.lua
+++ b/src/scripts/demonwalker/Code.lua
@@ -21,224 +21,329 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --]===]
-demonnic = demonnic or {}
-demonnic.autowalker = demonnic.autowalker or {}
-demonnic.autowalker.config = demonnic.autowalker.config or {}
-if demonnic.autowalker.enabled == nil then
-  demonnic.autowalker.enabled = false
+
+demonwalker = demonwalker or {}
+demonwalker.saveFile = getMudletHomeDir() .. "/demonwalkerconfig.lua"
+demonwalker.timerName = "demonwalkerPerfTimer"
+demonwalker.config = demonwalker.config or {}
+if demonwalker.enabled == nil then
+  demonwalker.enabled = false
 end
 
--- Set to false if you don't want to go back to the room you start the walker in when it's done
-if demonnic.autowalker.config.returnToStart == nil then
-  demonnic.autowalker.config.returnToStart = true
-end
-demonnic.autowalker.config.avoidList = demonnic.autowalker.config.avoidList or {}
-
-function demonnic:echo(msg)
-  cecho(string.format("\n<blue>(<green>Demonnic<blue>):<white> %s", msg))
+function demonwalker:echo(msg)
+  cecho(string.format("\n<blue>(<green>Demonwalker<blue>):<white> %s", msg))
 end
 
-function demonnic:findAndRemove(targetTable, item)
-  local index = table.index_of(targetTable, item)
-  if index then
-    table.remove(targetTable, index)
-    return true
-  end
-  return false
+function demonwalker:save()
+  table.save(demonwalker.saveFile, demonwalker.config)
 end
 
-function demonnic.autowalker:addAvoidRoom(roomID)
-  local ridType = type(roomID)
-  local avoidList = demonnic.autowalker.config.avoidList
-  if ridType == "number" then
-    if not table.index_of(avoidList, roomID) then
-      avoidList[#avoidList+1] = roomID
-    end
-  elseif ridType == "table" then
-    for _,rid in ipairs(roomID) do
-      demonnic.autowalker:addAvoidRoom(rid)
-    end
-  elseif ridType == "string" then
-    local rid = tonumber(roomID)
-    if rid then
-      demonnic.autowalker:addAvoidRoom(rid)
-    end
+function demonwalker:load()
+  local config = {}
+  local cfg = {}
+  local existingSave = io.exists(demonwalker.saveFile)
+  if existingSave then
+    table.load(demonwalker.saveFile, cfg)
   end
-end
-
-function demonnic.autowalker:removeAvoidRoom(roomID)
-  local ridType = type(roomID)
-  local avoidList = demonnic.autowalker.config.avoidList
-  if ridType == "number" then
-    demonnic:findAndRemove(avoidList, roomID)
-  elseif ridType == "table" then
-    for _,rid in ipairs(roomID) do
-      demonnic:findAndRemove(avoidList, rid)
-    end
-  elseif ridType == "string" then
-    local rid = tonumber(roomID)
-    if rid then
-      demonnic:findAndRemove(avoidList, rid)
-    end
-  end
-end
-
-function demonnic.autowalker:filterOutAvoidRooms(rooms, roomsToAvoid)
-  local remainingRooms = {}
-  roomsToAvoid = roomsToAvoid or {}
-  for _,roomID in ipairs(rooms) do
-    if not (table.index_of(demonnic.autowalker.config.avoidList, roomID) or table.index_of(remainingRooms, roomID) or table.index_of(roomsToAvoid, roomID)) then
-      remainingRooms[#remainingRooms+1] = roomID
-    end
-  end
-  return remainingRooms
-end
-
-function demonnic.autowalker:init(rooms, roomsToAvoid)
-  if demonnic.autowalker.enabled then
-    return
-  end
-  if rooms == nil then
-    rooms = {}
-  end
-  if type(rooms) ~= "table" then
-    demonnic:echo("You tried to initialize the autowalker with an argument, and it was not a table of room ID numbers. Try again")
-    return
-  end
-  if roomsToAvoid == nil then
-    roomsToAvoid = {}
-  end
-  if type(roomsToAvoid) ~= "table" then
-    demonnic:echo("demonnic.autowalker:init(rooms, roomsToAvoid): roomsToAvoid must be a table if provided, got " .. type(roomsToAvoid))
-  end
-  demonnic.autowalker.enabled = true
-  local currentRoom = mmp.currentroom
-  demonnic.autowalker.currentRoom = currentRoom
-  demonnic.autowalker.startingRoom = currentRoom
-  local area = getRoomArea(currentRoom)
-  demonnic.autowalker.area = area
-  if #rooms ~= 0 then
-    area = getRoomArea(rooms[1])
-    demonnic.autowalker.area = area
-    if table.index_of(rooms, currentRoom) then
-      demonnic:findAndRemove(rooms, currentRoom)
-    end
-    demonnic.autowalker.remainingRooms = demonnic.autowalker:filterOutAvoidRooms(rooms, roomsToAvoid)
+  if cfg.returnToStart == nil then
+    config.returnToStart = true
   else
-    local areaRooms = getAreaRooms(area)
-    demonnic:findAndRemove(areaRooms, currentRoom)
-    if areaRooms[0] then
-      areaRooms[#areaRooms+1] = areaRooms[0]
-      areaRooms[0] = nil
-    end
-    demonnic.autowalker.remainingRooms = demonnic.autowalker:filterOutAvoidRooms(areaRooms, roomsToAvoid)
+    config.returnToStart = true
   end
-  demonnic.autowalker:registerEventHandlers()
+  config.avoidList = cfg.avoidList or {}
+  config.breadth = cfg.breadth or 10
+  if not _comp(config, cfg) then
+    -- there is a new value which was not in the save file, or there is no savefile yet
+    demonwalker:save()
+  end
+  demonwalker.config = config
+end
+
+function demonwalker:addAvoidRoom(roomID)
+  local ridType = type(roomID)
+  local avoidList = demonwalker.config.avoidList
+  if ridType == "number" then
+    avoidList[roomID] = true
+  elseif ridType == "table" then
+    for _,rid in ipairs(roomID) do
+      avoidList[rid] = true
+    end
+  elseif ridType == "string" then
+    local rid = tonumber(roomID)
+    if rid then
+      avoidList[rid] = true
+    end
+  end
+  demonwalker:save()
+end
+
+function demonwalker:removeAvoidRoom(roomID)
+  local ridType = type(roomID)
+  local avoidList = demonwalker.config.avoidList
+  if ridType == "number" then
+    avoidList[roomID] = nil
+  elseif ridType == "table" then
+    for _,rid in ipairs(roomID) do
+      avoidList[rid] = nil
+    end
+  elseif ridType == "string" then
+    local rid = tonumber(roomID)
+    if rid then
+      avoidList[rid] = nil
+    end
+  end
+  demonwalker:save()
+end
+
+function demonwalker:removeUnreachable()
+  local rooms = {}
+  for room,_ in pairs(demonwalker.remainingRooms) do
+    local ok,_ = getPath(demonwalker.currentRoom, room)
+    if ok then
+      rooms[room] = true
+    end
+  end
+  demonwalker.remainingRooms = rooms
+end
+
+function demonwalker:init(options)
+  if demonwalker.enabled then
+    return
+  end
+  options = options or {}
+  local rooms = options.rooms or {}
+  local roomsToAvoid = options.avoidRooms or {}
+  demonwalker.search = options.search or {}
+  demonwalker.enabled = true
+  local currentRoom = mmp.currentroom
+  demonwalker.currentRoom = currentRoom
+  demonwalker.startingRoom = currentRoom
+  demonwalker.performanceTimes = {}
+  local area = getRoomArea(currentRoom)
+  demonwalker.area = area
+  if #rooms ~= 0 then
+    demonwalker.area = getRoomArea(rooms[1])
+  else
+    rooms = getAreaRooms(area)
+    if rooms[0] then
+      rooms[#rooms+1] = rooms[0]
+      rooms[0] = nil
+    end
+  end
+  demonwalker.remainingRooms = {}
+  for _,roomID in ipairs(rooms) do
+    demonwalker.remainingRooms[roomID] = true
+  end
+  for _,roomID in ipairs(demonwalker.config.avoidList) do
+    demonwalker.remainingRooms[roomID] = nil
+  end
+  for _,roomID in ipairs(roomsToAvoid) do
+    demonwalker.remainingRooms[roomID] = nil
+  end
+  demonwalker:removeUnreachable()
+  demonwalker:registerEventHandlers()
   raiseEvent("demonwalker.arrived")
 end
 
-function demonnic.autowalker:stop()
-  if not demonnic.autowalker.enabled then
+function demonwalker:stop()
+  if not demonwalker.enabled then
     return
   end
-  demonnic.autowalker.currentRoom = nil
-  demonnic.autowalker.remainingRooms = nil
-  demonnic.autowalker.enabled = false
-  demonnic.autowalker:removeEventHandlers()
+  demonwalker.currentRoom = nil
+  demonwalker.remainingRooms = nil
+  demonwalker.enabled = false
+  demonwalker:removeEventHandlers()
   raiseEvent("demonwalker.finished")
-  if demonnic.autowalker.config.returnToStart then
-    mmp.gotoRoom(demonnic.autowalker.startingRoom)
+  if demonwalker.config.returnToStart then
+    mmp.gotoRoom(demonwalker.startingRoom)
   end
 end
 
-function demonnic.autowalker:move()
-  if not demonnic.autowalker.enabled then
+function demonwalker:move()
+  if not demonwalker.enabled then
     return
   end
-  demonnic.autowalker.nextRoom = demonnic.autowalker:closestRoom()
-  if demonnic.autowalker.nextRoom ~= "" then
-    tempTimer(0, function() mmp.gotoRoom(demonnic.autowalker.nextRoom) end)
+  if mmp.paused then
+    mmp.pause()
+    return
+  end
+  demonwalker.nextRoom = demonwalker:closestRoom()
+  if demonwalker.nextRoom ~= "" then
+    tempTimer(0, function() mmp.gotoRoom(demonwalker.nextRoom) end)
   else
     raiseEvent("demonwalker.stop")
   end
 end
 
-function demonnic.autowalker:arrived()
-  if tonumber(mmp.currentroom) == tonumber(demonnic.autowalker.nextRoom) then
-    demonnic.autowalker.currentRoom = mmp.currentroom
-    demonnic:findAndRemove(demonnic.autowalker.remainingRooms, mmp.currentroom)
+function demonwalker:arrived()
+  if tonumber(mmp.currentroom) == tonumber(demonwalker.nextRoom) then
+    demonwalker.currentRoom = mmp.currentroom
+    demonwalker.remainingRooms[mmp.currentroom] = nil
     raiseEvent("demonwalker.arrived")
   else
     debugc("demonwalker: Somehow, the mudlet mapper says we have arrived but it is not to the room we said to go to.")
   end
 end
 
-function demonnic.autowalker:failedPath()
-  demonnic:findAndRemove(demonnic.autowalker.remainingRooms, demonnic.autowalker.nextRoom)
-  demonnic.autowalker.currentRoom = mmp.currentroom
+function demonwalker:failedPath()
+  demonwalker.remainingRooms[demonwalker.nextRoom] = nil
+  demonwalker.currentRoom = mmp.currentroom
   raiseEvent("demonwalker.move")
 end
 
-function demonnic.autowalker:removeEventHandlers()
-  for _, handlerID in pairs(demonnic.autowalker.eventHandlers) do
+function demonwalker:removeEventHandlers()
+  for _, handlerID in pairs(demonwalker.eventHandlers) do
     killAnonymousEventHandler(handlerID)
   end
 end
 
-function demonnic.autowalker:registerEventHandlers()
-  demonnic.autowalker.eventHandlers = demonnic.autowalker.eventHandlers or {}
-  demonnic.autowalker:removeEventHandlers()
-  demonnic.autowalker.eventHandlers.move = registerAnonymousEventHandler("demonwalker.move", demonnic.autowalker.move)
-  demonnic.autowalker.eventHandlers.stop = registerAnonymousEventHandler("demonwalker.stop", demonnic.autowalker.stop)
-  demonnic.autowalker.eventHandlers.arrived = registerAnonymousEventHandler("mmapper arrived", demonnic.autowalker.arrived)
-  demonnic.autowalker.eventHandlers.failedPath = registerAnonymousEventHandler("mmapper failed path", demonnic.autowalker.failedPath)
+function demonwalker:registerEventHandlers()
+  demonwalker.eventHandlers = demonwalker.eventHandlers or {}
+  demonwalker:removeEventHandlers()
+  demonwalker.eventHandlers.move = registerAnonymousEventHandler("demonwalker.move", demonwalker.move)
+  demonwalker.eventHandlers.stop = registerAnonymousEventHandler("demonwalker.stop", demonwalker.stop)
+  demonwalker.eventHandlers.arrived = registerAnonymousEventHandler("mmapper arrived", demonwalker.arrived)
+  demonwalker.eventHandlers.failedPath = registerAnonymousEventHandler("mmapper failed path", demonwalker.failedPath)
 end
 
-function demonnic.autowalker:getAdjacantRooms(roomID)
-  local adjacentRooms = table.keys(getSpecialExits(roomID))
+function demonwalker:getAdjacentRooms(roomID)
+  local adjacentRooms = getSpecialExits(roomID)
   local exits = getRoomExits(roomID)
   for _,id in pairs(exits) do
-    adjacentRooms[#adjacentRooms+1] = id
+    adjacentRooms[id] = true
   end
   return adjacentRooms
 end
 
-function demonnic.autowalker:extractFirstUnvisitedRoom(rooms)
-  local remainingRooms = demonnic.autowalker.remainingRooms
-  for _,id in ipairs(rooms) do
-    if table.index_of(remainingRooms, id) then
+function demonwalker:extractFirstUnvisitedRoom(rooms)
+  local remainingRooms = demonwalker.remainingRooms
+  for id,_ in ipairs(rooms) do
+    if remainingRooms[id] then
       return id
     end
   end
   return nil
 end
 
-function demonnic.autowalker:closestRoom()
-  local adjacentRooms = demonnic.autowalker:getAdjacantRooms(mmp.currentroom)
-  local remainingRooms = demonnic.autowalker.remainingRooms
-  if not remainingRooms then return "" end
-  if #remainingRooms == 0 then return "" end
-  local roomID
-  -- check all the directly adjacent rooms
-  roomID = demonnic.autowalker:extractFirstUnvisitedRoom(adjacentRooms)
-  if roomID then return roomID end
+function demonwalker:startPerfTimer()
+  createStopWatch(demonwalker.timerName)
+  resetStopWatch(demonwalker.timerName)
+  startStopWatch(demonwalker.timerName)
+end
 
-  -- ok, check all the rooms 2 steps away
-  for _,id in ipairs(adjacentRooms) do
-    local adjRooms = demonnic.autowalker:getAdjacantRooms(id)
-    roomID = demonnic.autowalker:extractFirstUnvisitedRoom(adjRooms)
-    if roomID then return roomID end
+function demonwalker:recordPerfTime(steps, checks)
+  local perfTime = getStopWatchTime(demonwalker.timerName)
+  stopStopWatch(demonwalker.timerName)
+  demonwalker:echo(string.format("Took %.5f seconds to find our room at %d distance and %d checks\n", perfTime, steps, checks))
+  demonwalker.performanceTimes[#demonwalker.performanceTimes+1] = {time = perfTime, steps = steps, checks = checks}
+end
+
+function demonwalker:performanceReport()
+  local perfTable = demonwalker.performanceTimes
+  local timesMoved = #perfTable
+  if timesMoved == 0 then
+    demonwalker:echo("No performance report to generate, have not moved")
+    return
   end
+  local steps = {}
+  local times = {}
+  local checks = {}
+  local totalSteps = 0
+  local totalTime = 0
+  local totalChecks = 0
+  for _, info in ipairs(perfTable) do
+    totalSteps = totalSteps + info.steps
+    totalTime = totalTime + info.time
+    totalChecks = totalChecks + info.checks
+    steps[#steps+1] = info.steps
+    times[#times+1] = info.time
+    checks[#checks+1] = info.checks
+  end
+  local averageTime = totalTime / timesMoved
+  local averageSteps = totalSteps / timesMoved
+  local averageChecks = totalChecks / timesMoved
+  table.sort(steps)
+  table.sort(times)
+  table.sort(checks)
+  local half = timesMoved / 2
+  local medianSteps = 0
+  local medianTime = 0
+  local medianChecks = 0
+  local roundedHalf = math.ceil(half)
+  if roundedHalf > half then
+    medianSteps = steps[roundedHalf]
+    medianTime = times[roundedHalf]
+    medianChecks = checks[roundedHalf]
+  else
+    medianSteps = (steps[half] + steps[half + 1]) / 2
+    medianTime = (times[half] + times[half+1]) / 2
+    medianChecks = (checks[half] + checks[half+1]) / 2
+  end
+  demonwalker:echo("Performance report of current demonwalk!")
+  demonwalker:echo("Note: Number of steps actually taken may be more or less, as the walker does not always")
+  demonwalker:echo("take the reported number of steps due to mmp overshooting or some interruption.")
+  demonwalker:echo(string.format("Total times moved: %d", timesMoved))
+  demonwalker:echo(string.format("Total steps taken: %d", totalSteps))
+  demonwalker:echo(string.format("Avg steps per    : %.3f", averageSteps))
+  demonwalker:echo(string.format("Median steps per : %.3f", medianSteps))
+  demonwalker:echo(string.format("Total time calc. : %.3f", totalTime))
+  demonwalker:echo(string.format("Avg time per     : %.3f", averageTime))
+  demonwalker:echo(string.format("Median time per  : %.3f", medianTime))
+  demonwalker:echo(string.format("Total checks     : %d", totalChecks))
+  demonwalker:echo(string.format("Avg checks per   : %.3f", averageChecks))
+  demonwalker:echo(string.format("Median checks per: %.3f", medianChecks))
+end
 
-  -- fine, I'll brute force it.
+function demonwalker:closestRoom()
+  local remainingRooms = demonwalker.remainingRooms
+  local startingRoom = mmp.currentroom
+  if not remainingRooms or table.is_empty(remainingRooms) then return "" end
+  demonwalker:startPerfTimer()
+  local roomsToCheck = {
+    [startingRoom] = true
+  }
+  local numberOfChecks = 0
+  for iteration = 1, demonwalker.config.breadth do
+    if demonwalker.config.debug then
+      demonwalker:echo("Iteration: " .. iteration)
+    end
+    local newRooms = {}
+    for room,_ in pairs(roomsToCheck) do
+      if demonwalker.config.debug then
+        demonwalker:echo("Checking adjacent rooms of :" .. room)
+      end
+      for id,_ in pairs(demonwalker:getAdjacentRooms(room)) do
+        numberOfChecks = numberOfChecks + 1
+        if remainingRooms[id] then
+          demonwalker:recordPerfTime(iteration, numberOfChecks)
+          return id
+        end
+        newRooms[id] = true
+      end
+    end
+    roomsToCheck = newRooms
+  end
+  if demonwalker.config.debug then
+    demonwalker:echo("Did not find a room within the configured breadth:" .. numberOfChecks)
+  end
+  -- we didn't find an unvisited room within demonwalker.config.breadth steps, so now let's loop the remaining rooms list
   local distance = 99999
-  for _, v in pairs(remainingRooms) do
-    local ok, pathLength = getPath(demonnic.autowalker.currentRoom, v)
+  local minDistance = demonwalker.config.breadth + 1
+  local targetRoom = ""
+  for roomID,_ in pairs(remainingRooms) do
+    numberOfChecks = numberOfChecks + 1
+    local ok, pathLength = getPath(startingRoom, roomID)
     if ok and pathLength < distance then
       distance = pathLength
-      roomID = v
-      if distance <= 3 then return roomID end
+      targetRoom = roomID
+      if distance <= minDistance then
+        demonwalker:recordPerfTime(distance, numberOfChecks)
+        return targetRoom
+      end
     end
   end
-  return roomID or ""
+  demonwalker:recordPerfTime(distance, numberOfChecks)
+  return targetRoom
 end
+
+if _comp(demonwalker.config, {}) then demonwalker:load() end

--- a/src/scripts/demonwalker/Code.lua
+++ b/src/scripts/demonwalker/Code.lua
@@ -35,6 +35,17 @@ function demonwalker:echo(msg)
   cecho(string.format("\n<purple>(<green>Demonwalker<purple>):<white> %s", msg))
 end
 
+function demonwalker:debugEcho(msg)
+  if not demonwalker.config.debug then return end
+  local msgType = type(msg)
+  if msgType == "table" then
+    demonwalker:echo("DEBUG DISPLAY FOLLOWS\n")
+    display(msg)
+    return
+  end
+  demonwalker:echo("DEBUG: " .. tostring(msg))
+end
+
 function demonwalker:save()
   table.save(demonwalker.saveFile, demonwalker.config)
 end
@@ -269,9 +280,7 @@ function demonwalker.checkForItems(event, ...)
   local atDestination = demonwalker:atDestination()
   for _,item in ipairs(list.items) do
     if searchTargets[item.name] then
-      if demonwalker.config.debug then
-        demonwalker:echo("Stopping because we found something on the search list")
-      end
+      demonwalker:debugEcho("Stopping because we found something on the search list")
       if not atDestination then
         mmp.pause("on")
       end
@@ -279,7 +288,7 @@ function demonwalker.checkForItems(event, ...)
       return
     end
   end
-  demonwalker:echo("Nothing here, moving on")
+  demonwalker:debugEcho("Nothing here, moving on")
   if atDestination then raiseEvent("demonwalker.move") end
 end
 
@@ -354,9 +363,7 @@ end
 function demonwalker:recordPerfTime(steps, checks)
   local perfTime = getStopWatchTime(demonwalker.timerName)
   stopStopWatch(demonwalker.timerName)
-  if demonwalker.config.debug then
-    demonwalker:echo(string.format("Took %.5f seconds to find our room at %d distance and %d checks\n", perfTime, steps, checks))
-  end
+  demonwalker:debugEcho(string.format("Took %.5f seconds to find our room at %d distance and %d checks\n", perfTime, steps, checks))
   demonwalker.performanceTimes[#demonwalker.performanceTimes+1] = {time = perfTime, steps = steps, checks = checks}
 end
 
@@ -436,19 +443,13 @@ function demonwalker:closestRoom()
   }
   local numberOfChecks = 0
   for iteration = 1, demonwalker.config.breadth do
-    if demonwalker.config.debug then
-      demonwalker:echo("Iteration: " .. iteration)
-    end
+    demonwalker:debugEcho("Iteration: " .. iteration)
     local newRooms = {}
     for room,_ in pairs(roomsToCheck) do
-      if demonwalker.config.debug then
-        demonwalker:echo("Checking adjacent rooms of :" .. room)
-      end
+      demonwalker:debugEcho("Checking adjacent rooms of :" .. room)
       for id,_ in pairs(demonwalker:getAdjacentRooms(room)) do
         numberOfChecks = numberOfChecks + 1
-        if demonwalker.config.debug then
-          demonwalker:echo("Checking roomID: " .. id)
-        end
+        demonwalker:debugEcho("Checking roomID: " .. id)
         if remainingRooms[id] then
           demonwalker:recordPerfTime(iteration, numberOfChecks)
           return id
@@ -458,9 +459,7 @@ function demonwalker:closestRoom()
     end
     roomsToCheck = newRooms
   end
-  if demonwalker.config.debug then
-    demonwalker:echo("Did not find a room within the configured breadth:" .. numberOfChecks)
-  end
+  demonwalker:debugEcho("Did not find a room within the configured breadth:" .. numberOfChecks)
   -- we didn't find an unvisited room within demonwalker.config.breadth steps, so now let's loop the remaining rooms list
   local distance = 99999
   local minDistance = demonwalker.config.breadth + 1


### PR DESCRIPTION
## Changes
* Major performance rewrite.
* Makes the distance it will search from your current room for an unvisited room before searching the unvisited rooms for the closest one a configuration option
* Makes the configuration options persistent to disk
* Adds `dwalk` alias for interacting with demowalker
* Adds the capability to look for items/mobs and only raise the `demonwalker.arrived` event when it finds one, rather than when it arrives at a new room.
* Moves the entire thing from demonnic.autowalker to demonwalker table
* demonwalker:init(options) takes a table of options for the walker, whereas before demonnic.autowalker:init(rooms, avoidRooms) used separate parameters. When called with no parameters at all previous functionality is maintained, so demonwalker:init() is valid.
* keys for the options table for demonwalker:init(options)
  * rooms
    * List of roomIDs you want to visit. If not provided will be all rooms in the current area
    * IE { 12, 482, 1837 }
  * avoidRooms
    * List of roomIDs you do not want to visit. Can be used to filter unwanted rooms out when allowing the list of rooms to be autogenerated based on the area
    * IE { 88, 199, 12 }
  * searchTargets
    * List of items/mobs to search for. When provided, causes the walker to raise the arrived event when it finds one of the items or mobs, instead of when a new unvisited room has been reached.
    * IE {"a thief on a leaf", "a dracnari hunk", "a dracnari dreamer"}

The README was updated with full information.