### PR TITLE
Adding string.match support, tracking of failed rooms, type conversion for rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ If it can't get to a room, it just moves on to the next.
     * avoidRooms: a list of roomIDs to make sure is not included in **this** walk. Not saved between walks.
     * searchTargets: a list of items to check for. IE {"a thief on a leaf", "a dracnari hunk", "a dracnari dreamer"}.
       * If this list is provided, then demonwalker will check every room for each of these items, and if any of them are found then and only then will it raise `demonwalker.arrived`. This makes it easy to automate looking for one or more creatures or items in an area, without worrying about stopping the walker yourself.
+      * If you start an entry with `"Match:"` then it will use string.match to check for targets/items. For instance, `"Match:Drakt"` will stop for anything with `Drakt` in the name at all.
 * demonwalker:performanceReport()
   * prints out some performance information on the current walk if still running a walk, or the last walk if one has been completed.
+* demonwalker:getFailedRooms()
+  * Returns a table of roomIDs which could not be reached by demonwalker during the most recent walk.
 
 ## Events
 

--- a/mfile
+++ b/mfile
@@ -1,4 +1,4 @@
 {
   "package": "demonnicAutoWalker",
-  "version": "3.4"
+  "version": "3.5"
 }

--- a/src/aliases/demonwalker/dwalk.lua
+++ b/src/aliases/demonwalker/dwalk.lua
@@ -71,8 +71,10 @@ elseif command == "explore" then
   return
 elseif command == "update" then
   uninstallPackage("demonnicAutoWalker")
-  installPackage("https://github.com/demonnic/demonnicAutoWalker/releases/latest/download/demonnicAutoWalker.mpackage")
-  demonwalker:echo("demonnicAutoWalker package updated")
+  tempTimer(2, function()
+    installPackage("https://github.com/demonnic/demonnicAutoWalker/releases/latest/download/demonnicAutoWalker.mpackage")
+    demonwalker:echo("demonnicAutoWalker package updated")
+  end)
   return
 end
 demonwalker:usage(matches[1])


### PR DESCRIPTION
* adds tracking for failed rooms
  * demonwalker:getFailedRooms() to get a table with all the roomIDs you couldn't visit for some reason.
  * added the count of failed rooms to `dwalk report`
* begin a searchTarget entry with `"Match:"` and it will feed the rest into string.match to check for room items. 
  * IE `searchTargets = { "Match:Drakt" }` will stop for any item or mob with `Drakt` in the name.
* Fixes a bug where if you used `"2000"` for a roomID versus `2000` (so string rather than a number) it would just stop in the first room and get stuck. It will now use tonumber on everything you give to it as a roomID, and anything which cannot be converted is added to failedRooms
* Fixes a bug where if an item was found in the room you were speedwalking to last you sometimes had to tell the walker to move on twice.